### PR TITLE
std::find needs #include<algorithm>; size_t is unsigned

### DIFF
--- a/btree_test.cc
+++ b/btree_test.cc
@@ -1,5 +1,6 @@
 #include "btree.h"
 
+#include <algorithm>
 #include <map>
 
 #include "assert.h"
@@ -163,7 +164,7 @@ TEST_F(BTreeTest, RandomInsertUnique) {
     std_map.insert(std::make_pair(42, -1));
     values.push_back(42);
     //~ printf("insert %d = %d\n", 42, -1);
-    
+
     for (int loops = 0; loops < 1000; ++loops) {
         // Do an insert (alternating between new and old inserts)
         int value;

--- a/stupidunit.cc
+++ b/stupidunit.cc
@@ -178,7 +178,7 @@ void Test::printErrors() const {
 }
 
 const string& Test::stupidunitError(size_t i) const {
-    ASSERT(0 <= i && i < errors_.size());
+    ASSERT(i < errors_.size());
     return errors_[i];
 }
 


### PR DESCRIPTION
This tiny commit fixes compilation errors with gcc 9.2.0. Thanks.

References
http://www.cplusplus.com/reference/algorithm/find/
https://en.cppreference.com/w/c/types/size_t