### PR TITLE
Update Makefile to link with CXX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 WARNINGS = -Werror -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter
 
+LINK.o = $(LINK.cc)
+
 # gcc flags used for both debug and opt builds
 BASE_CXX_FLAGS := -MD $(CXXFLAGS) $(WARNINGS) -std=c++11
 
@@ -7,9 +9,6 @@ BASE_CXX_FLAGS := -MD $(CXXFLAGS) $(WARNINGS) -std=c++11
 CXXFLAGS = -g $(BASE_CXX_FLAGS)
 # Optimization flags
 #CXXFLAGS = -g -O3 -DNDEBUG $(BASE_CXX_FLAGS)
-
-# Link with the C++ standard library
-LDFLAGS=-lstdc++
 
 BINARIES = btree_test randomgenerator_test tpccclient_test tpcctables_test tpccgenerator_test tpcc
 


### PR DESCRIPTION
I'm using `g++ 9.3`, in addition to https://github.com/evanj/tpccbench/pull/1 I got:

```bash
g++ -g -MD  -Werror -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -std=c++11   -c -o btree_test.o btree_test.cc
g++ -g -MD  -Werror -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -std=c++11   -c -o stupidunit.o stupidunit.cc
cc -lstdc++  btree_test.o stupidunit.o   -o btree_test
/usr/bin/ld: btree_test.o: in function `__static_initialization_and_destruction_0(int, int)':
/usr/include/c++/9/iostream:74: undefined reference to `std::ios_base::Init::Init()'
/usr/bin/ld: /usr/include/c++/9/iostream:74: undefined reference to `std::ios_base::Init::~Init()'
/usr/bin/ld: btree_test.o: in function `Test::~Test()':
/home/user/tpccbench/stupidunit.h:34: undefined reference to `operator delete(void*)'
/usr/bin/ld: btree_test.o: in function `BTreeTest::~BTreeTest()':
/home/user/tpccbench/btree_test.cc:13: undefined reference to `operator delete(void*)'
```

Fixed by linking with cxx, according to [this answer](https://stackoverflow.com/questions/13375394/default-linker-setting-in-makefile-for-linking-c-object-files).